### PR TITLE
V0.30.0 terra migrate absolute tx position

### DIFF
--- a/x/wasm/keeper/legacy.go
+++ b/x/wasm/keeper/legacy.go
@@ -1,10 +1,18 @@
 package keeper
 
 import (
+	"github.com/CosmWasm/wasmd/x/wasm/types"
 	legacytypes "github.com/CosmWasm/wasmd/x/wasm/types/legacy"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
+
+// SetContractInfo stores ContractInfo for the given contractAddress
+func (k Keeper) SetLegacyContractInfo(ctx sdk.Context, contractAddress sdk.AccAddress, codeInfo legacytypes.ContractInfo) {
+	store := ctx.KVStore(k.storeKey)
+	b := k.cdc.MustMarshal(&codeInfo)
+	store.Set(types.GetContractAddressKey(contractAddress), b)
+}
 
 // IterateLegacyContractInfo iterates all contract infos in legacy terra wasm store
 func (k Keeper) IterateLegacyContractInfo(ctx sdk.Context, cb func(legacytypes.ContractInfo) bool) {

--- a/x/wasm/keeper/migrations.go
+++ b/x/wasm/keeper/migrations.go
@@ -95,14 +95,16 @@ func (m Migrator) Migrate1to2(ctx sdk.Context) error {
 	m.keeper.Logger(ctx).Info("#### Migrating Contract Info ###")
 	m.keeper.IterateLegacyContractInfo(ctx, func(contractInfo legacytypes.ContractInfo) bool {
 
-		// Migrate AbsoluteTxPosition
+		// Migrate AbsoluteTxPosition (Testing needed)
+		// I am afraid that setting all contracts at one absolute tx position will break query
 		createdAt := types.NewAbsoluteTxPosition(ctx)
 
 		creatorAddr, _ := sdk.AccAddressFromBech32(contractInfo.Creator)
 		admin, _ := sdk.AccAddressFromBech32(contractInfo.Admin)
+		contractAddr, _ := sdk.AccAddressFromBech32(contractInfo.Address)
 
 		newContract := types.NewContractInfo(contractInfo.CodeID, creatorAddr, admin, "", createdAt)
-		m.keeper.storeContractInfo(ctx, contractInfo.ContractAddress, newContract)
+		m.keeper.storeContractInfo(ctx, contractAddr, &newContract)
 
 		return false
 	})

--- a/x/wasm/keeper/migrations.go
+++ b/x/wasm/keeper/migrations.go
@@ -83,12 +83,8 @@ func (m Migrator) Migrate1to2(ctx sdk.Context) error {
 
 	ctx.Logger().Info("### Migrating Code Info ###")
 	m.keeper.IterateLegacyCodeInfo(ctx, func(codeInfo legacytypes.CodeInfo) bool {
-		creatorAddr, err := sdk.AccAddressFromBech32(codeInfo.Creator)
-		if err != nil {
-			m.keeper.Logger(ctx).Error("was not able to parse creator address %s", codeInfo)
-			return false
-		}
-		err = m.createCodeFromLegacy(ctx, creatorAddr, codeInfo.CodeID, codeInfo.CodeHash)
+		creatorAddr, _ := sdk.AccAddressFromBech32(codeInfo.Creator)
+		err := m.createCodeFromLegacy(ctx, creatorAddr, codeInfo.CodeID, codeInfo.CodeHash)
 		if err != nil {
 			m.keeper.Logger(ctx).Error("Was not able to store legacy code ID")
 		}
@@ -96,10 +92,20 @@ func (m Migrator) Migrate1to2(ctx sdk.Context) error {
 	})
 
 	// TODO
-	/*m.keeper.Logger(ctx).Info("#### Migrating Contract Info ###")
+	m.keeper.Logger(ctx).Info("#### Migrating Contract Info ###")
 	m.keeper.IterateLegacyContractInfo(ctx, func(contractInfo legacytypes.ContractInfo) bool {
+
+		// Migrate AbsoluteTxPosition
+		createdAt := types.NewAbsoluteTxPosition(ctx)
+
+		creatorAddr, _ := sdk.AccAddressFromBech32(contractInfo.Creator)
+		admin, _ := sdk.AccAddressFromBech32(contractInfo.Admin)
+
+		newContract := types.NewContractInfo(contractInfo.CodeID, creatorAddr, admin, "", createdAt)
+		m.keeper.storeContractInfo(ctx, contractInfo.ContractAddress, newContract)
+
 		return false
-	})*/
+	})
 
 	/*m.keeper.IterateContractInfo(ctx, func(contractAddr sdk.AccAddress, contractInfo types.ContractInfo) bool {
 		creator := sdk.MustAccAddressFromBech32(contractInfo.Creator)

--- a/x/wasm/types/keys.go
+++ b/x/wasm/types/keys.go
@@ -25,9 +25,8 @@ const (
 // nolint
 var (
 	CodeKeyPrefix                                  = []byte{0x01}
-	ContractKeyPrefix                              = []byte{0x02}
 	ContractStorePrefix                            = []byte{0x03}
-	SequenceKeyPrefix                              = []byte{0x04}
+	SequenceKeyPrefix                              = []byte{0x99}
 	ContractCodeHistoryElementPrefix               = []byte{0x05}
 	ContractByCodeIDAndCreatedSecondaryIndexPrefix = []byte{0x06}
 	PinnedCodeIndexPrefix                          = []byte{0x07}
@@ -36,6 +35,9 @@ var (
 
 	KeyLastCodeID     = append(SequenceKeyPrefix, []byte("lastCodeId")...)
 	KeyLastInstanceID = append(SequenceKeyPrefix, []byte("lastContractId")...)
+
+	// Compatible key with old
+	ContractKeyPrefix = []byte{0x04}
 )
 
 // GetCodeKey constructs the key for retreiving the ID for the WASM code
@@ -46,7 +48,7 @@ func GetCodeKey(codeID uint64) []byte {
 
 // GetContractAddressKey returns the key for the WASM contract instance
 func GetContractAddressKey(addr sdk.AccAddress) []byte {
-	return append(ContractKeyPrefix, addr...)
+	return append(ContractKeyPrefix, address.MustLengthPrefix(addr)...)
 }
 
 // GetContractsByCreatorPrefix returns the contracts by creator prefix for the WASM contract instance

--- a/x/wasm/types/keys.go
+++ b/x/wasm/types/keys.go
@@ -24,8 +24,7 @@ const (
 
 // nolint
 var (
-	CodeKeyPrefix                                  = []byte{0x01}
-	ContractStorePrefix                            = []byte{0x03}
+	ContractStorePrefix                            = []byte{0x98}
 	SequenceKeyPrefix                              = []byte{0x99}
 	ContractCodeHistoryElementPrefix               = []byte{0x05}
 	ContractByCodeIDAndCreatedSecondaryIndexPrefix = []byte{0x06}
@@ -37,6 +36,7 @@ var (
 	KeyLastInstanceID = append(SequenceKeyPrefix, []byte("lastContractId")...)
 
 	// Compatible key with old
+	CodeKeyPrefix     = []byte{0x03}
 	ContractKeyPrefix = []byte{0x04}
 )
 

--- a/x/wasm/types/legacy/keys.go
+++ b/x/wasm/types/legacy/keys.go
@@ -1,4 +1,4 @@
-package legacy 
+package legacy
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -37,6 +37,8 @@ const (
 // - 0x04<accAddress_Bytes>: ContractInfo
 //
 // - 0x05<accAddress_Bytes>: KVStore for contract
+
+// Need to remove this file and merge it with canonical keys.go. There can only be one store at a time.
 var (
 	LastCodeIDKey     = []byte{0x01}
 	LastInstanceIDKey = []byte{0x02}


### PR DESCRIPTION
Closes: #1 

1. Get AbsoluteTxPosition from current block
2. Change store key to be compatible with old store key
3. Add a basic test to check after migration, store can get migrated contract (not nil)

Need testing for AbsoluteTxPosition in case of querying contract at same position