### PR TITLE
Add `FundCommunityPoolMsg`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -130,6 +130,8 @@ require (
 )
 
 replace (
+	//This replace is for backported FundCommunityPoolMsg in wasmvm
+	github.com/CosmWasm/wasmvm => github.com/classic-terra/wasmvm v1.1.1-terra.0
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 	// Fix upstream GHSA-h395-qcrw-5vmq vulnerability.
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/CosmWasm/wasmvm v1.1.1 h1:0xtdrmmsP9fibe+x42WcMkp5aQ738BICgcH3FNVLzm4=
-github.com/CosmWasm/wasmvm v1.1.1/go.mod h1:ei0xpvomwSdONsxDuONzV7bL1jSET1M8brEx0FCXc+A=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
@@ -144,6 +142,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
+github.com/classic-terra/wasmvm v1.1.1-terra.0 h1:jfr+oc0uY6bfL1TyO3m/Yn6kbIZzPQ1GgghzI/EsyE8=
+github.com/classic-terra/wasmvm v1.1.1-terra.0/go.mod h1:ei0xpvomwSdONsxDuONzV7bL1jSET1M8brEx0FCXc+A=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/x/wasm/keeper/handler_plugin_encoders.go
+++ b/x/wasm/keeper/handler_plugin_encoders.go
@@ -143,6 +143,16 @@ func EncodeDistributionMsg(sender sdk.AccAddress, msg *wasmvmtypes.DistributionM
 			ValidatorAddress: msg.WithdrawDelegatorReward.Validator,
 		}
 		return []sdk.Msg{&withdrawMsg}, nil
+	case msg.FundCommunityPool != nil:
+		amt, err := ConvertWasmCoinsToSdkCoins(msg.FundCommunityPool.Amount)
+		if err != nil {
+			return nil, err
+		}
+		fundMsg := distributiontypes.MsgFundCommunityPool{
+			Depositor: sender.String(),
+			Amount:    amt,
+		}
+		return []sdk.Msg{&fundMsg}, nil
 	default:
 		return nil, sdkerrors.Wrap(types.ErrUnknownMsg, "unknown variant of Distribution")
 	}

--- a/x/wasm/keeper/handler_plugin_encoders_test.go
+++ b/x/wasm/keeper/handler_plugin_encoders_test.go
@@ -350,6 +350,28 @@ func TestEncoding(t *testing.T) {
 				},
 			},
 		},
+		"distribution fund community pool": {
+			sender: addr1,
+			srcMsg: wasmvmtypes.CosmosMsg{
+				Distribution: &wasmvmtypes.DistributionMsg{
+					FundCommunityPool: &wasmvmtypes.FundCommunityPoolMsg{
+						Amount: wasmvmtypes.Coins{
+							wasmvmtypes.NewCoin(200, "stones"),
+							wasmvmtypes.NewCoin(200, "feathers"),
+						},
+					},
+				},
+			},
+			output: []sdk.Msg{
+				&distributiontypes.MsgFundCommunityPool{
+					Depositor: addr1.String(),
+					Amount: sdk.NewCoins(
+						sdk.NewInt64Coin("stones", 200),
+						sdk.NewInt64Coin("feathers", 200),
+					),
+				},
+			},
+		},
 		"stargate encoded bank msg": {
 			sender: addr2,
 			srcMsg: wasmvmtypes.CosmosMsg{

--- a/x/wasm/keeper/handler_plugin_encoders_test.go
+++ b/x/wasm/keeper/handler_plugin_encoders_test.go
@@ -356,8 +356,8 @@ func TestEncoding(t *testing.T) {
 				Distribution: &wasmvmtypes.DistributionMsg{
 					FundCommunityPool: &wasmvmtypes.FundCommunityPoolMsg{
 						Amount: wasmvmtypes.Coins{
-							wasmvmtypes.NewCoin(200, "stones"),
 							wasmvmtypes.NewCoin(200, "feathers"),
+							wasmvmtypes.NewCoin(200, "stones"),
 						},
 					},
 				},


### PR DESCRIPTION
This is a backport to v1.1.1 for the following PRs:

- https://github.com/CosmWasm/wasmvm/pull/433/commits
- https://github.com/CosmWasm/wasmd/pull/1458

I made the backport so we can ultimately use this feature in Terra Classic and make it available for builders before it gets merged upstream.

I would strongly feel that this is actually consensus breaking. Thoughts?